### PR TITLE
Change `setup up` to `set up` in `test.yaml`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: setup up Python
+      - name: set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"


### PR DESCRIPTION
In the `.github/workflows/test.yml` the spelling is `setup up` but should be `set up`.