### PR TITLE
update pytest-asyncio to the current version

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -39,7 +39,7 @@ dev = [
 ]
 test = [
     "pytest (>=8.3.4, <9.0.0)",
-    "pytest-asyncio (>=0.25.3, <0.26.0)",
+    "pytest-asyncio (>=1.2.0, <2.0.0)",
 ]
 types = [
 ]

--- a/template/{% if use_pip %}requirements-dev.txt{% endif %}.jinja
+++ b/template/{% if use_pip %}requirements-dev.txt{% endif %}.jinja
@@ -1,5 +1,6 @@
 -r requirements.txt
 pytest
+pytest-asyncio
 mypy
 pylint
 ruff


### PR DESCRIPTION
Since [RoSys](https://github.com/zauberzeug/rosys/pull/354) no longer depends on an old pytest-asyncio version, we can update it here as well.

Fixes #16 