### PR TITLE
fix pipeline by using uv to install python and to cache dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: set up uv
         uses: astral-sh/setup-uv@v7
-      - name: set up Python
-        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-          cache: "pip"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: install Python
+        run: uv python install 3.11
       - name: install dependencies
         run: uv sync --locked
       - name: ${{ matrix.tools.command[0] }}
@@ -35,15 +35,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: set up uv
         uses: astral-sh/setup-uv@v7
-      - name: set up Python
-        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-          cache: "pip"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: install Python
+        run: uv python install 3.11
       - name: install dependencies
         run: |
           pipx install poetry
-          pipx install uv
           uv sync --locked
       - name: pytest
         run: uv run pytest


### PR DESCRIPTION
When switching to uv in the last release, the pipeline's caching mechanism wasn't updated. It still used `pip` to determine the packages to cache. But since `pip` is no longer available, the pipeline crashed in #22 .

This PR fixes that problem.