### PR TITLE
update pipelines to be more efficient

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Run Tests
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - "**.md"
+      - ".vscode/**"
+      - ".cursor/**"
 
 jobs:
   code-checks:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,16 +4,9 @@ on: [push]
 
 jobs:
   code-checks:
-    strategy:
-      fail-fast: false
-      matrix:
-        tools:
-          - command: ["mypy", "."]
-          - command: ["ruff", "check", "."]
-          - command: ["pylint", "."]
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    name: code check - ${{ matrix.tools.command[0] }}
+    name: code checks
     steps:
       - uses: actions/checkout@v4
       - name: set up uv
@@ -25,8 +18,28 @@ jobs:
         run: uv python install 3.11
       - name: install dependencies
         run: uv sync --locked
-      - name: ${{ matrix.tools.command[0] }}
-        run: uv run ${{ join(matrix.tools.command, ' ') }}
+      - run: uv run ruff check .
+        id: ruff
+        continue-on-error: true
+      - run: uv run mypy .
+        id: mypy
+        continue-on-error: true
+      - run: uv run pylint .
+        id: pylint
+        continue-on-error: true
+      - name: check results
+        if: always()
+        run: |
+          echo "| Tool | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| ruff | ${{ steps.ruff.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| mypy | ${{ steps.mypy.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| pylint | ${{ steps.pylint.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.ruff.outcome }}" = "failure" ] || \
+             [ "${{ steps.mypy.outcome }}" = "failure" ] || \
+             [ "${{ steps.pylint.outcome }}" = "failure" ]; then
+            exit 1
+          fi
 
   test:
     runs-on: ubuntu-latest

--- a/py-versions.jinja
+++ b/py-versions.jinja
@@ -22,3 +22,14 @@
 {% macro range(py_versions) -%}
 >={{ min(py_versions) }}, <{{ outside(py_versions) }}
 {%- endmacro -%}
+
+{# Return a list with the min and max python version #}
+{% macro minmax(py_versions) -%}
+{%- set min_version = min(py_versions) -%}
+{%- set max_version = max(py_versions) -%}
+{%- if min_version == max_version -%}
+[{{ min_version }}]
+{%- else -%}
+[{{ min_version}}, {{ max_version}}]
+{%- endif -%}
+{%- endmacro -%}

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -5,14 +5,7 @@ on: [push]
 
 jobs:
   code-checks:
-    strategy:
-      fail-fast: false
-      matrix:
-        tools:
-          - command: "mypy"
-          - command: "pylint"
-          - command: {% if use_precommit %}"pre-commit"{% else %}"ruff"{% endif %}
-    name: {% raw %}code check - ${{ matrix.tools.command }}{% endraw %}
+    name: code checks
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -22,23 +15,51 @@ jobs:
         uses: abatilo/actions-poetry@v4
       {%- elif use_uv %}
       - name: set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       {%- endif %}
       - name: set up Python
+        {%- if use_uv %}
+        run: uv python install {{ python.min(python_versions) }}
+        {%- else %}
         uses: actions/setup-python@v5
         with:
           python-version: "{{ python.min(python_versions) }}"
-          {%- if not use_uv %}
           cache: "{% if use_poetry %}poetry{% else %}pip{% endif %}"
-          {%- endif %}
+        {%- endif %}
       - name: install dependencies
         run: make install-ci
-      - name: {% raw %}${{ matrix.tools.command }}{% endraw %}
-        run: make {% raw %}${{ matrix.tools.command }}{% endraw %}
+      - name: mypy
+        id: mypy
+        run: make mypy
+        continue-on-error: true
+      - name: pylint
+        id: pylint
+        run: make pylint
+        continue-on-error: true
+      - name: {% if use_precommit %}pre-commit{% else %}ruff{% endif %}
+        id: ruff-or-precommit
+        run: make {% if use_precommit %}pre-commit{% else %}ruff{% endif %}
+        continue-on-error: true
+      - name: check results
+        if: always()
+        run: |
+          echo "| Tool | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| mypy | ${{ steps.mypy.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| pylint | ${{ steps.pylint.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| ruff/pre-commit | ${{ steps.ruff-or-precommit.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.mypy.outcome }}" = "failure" ] || \
+             [ "${{ steps.ruff-or-precommit.outcome }}" = "failure" ] || \
+             [ "${{ steps.pylint.outcome }}" = "failure" ]; then
+            exit 1
+          fi
   test:
     strategy:
       matrix:
-        python: {{ python_versions }}
+        python: {{ python.minmax(python_versions) }}
       fail-fast: false
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -49,15 +70,20 @@ jobs:
         uses: abatilo/actions-poetry@v4
       {%- elif use_uv %}
       - name: set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       {%- endif %}
       - name: setup up Python
+        {%- if use_uv %}
+        run: uv python install {{ python.min(python_versions) }}
+        {%- else %}
         uses: actions/setup-python@v5
         with:
-          python-version: {% raw %}${{ matrix.python }}{% endraw %}
-          {%- if not use_uv %}
+          python-version: "{{ python.min(python_versions) }}"
           cache: "{% if use_poetry %}poetry{% else %}pip{% endif %}"
-          {%- endif %}
+        {%- endif %}
       - name: install dependencies
         run: make install-ci
       - name: pytest

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -46,6 +46,7 @@ jobs:
       - name: check results
         if: always()
         run: |
+          {%- raw %}
           echo "| Tool | Result |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| mypy | ${{ steps.mypy.outcome }} |" >> $GITHUB_STEP_SUMMARY
@@ -56,6 +57,7 @@ jobs:
              [ "${{ steps.pylint.outcome }}" = "failure" ]; then
             exit 1
           fi
+          {%- endraw %}
   test:
     strategy:
       matrix:

--- a/template/.github/workflows/test.yml.jinja
+++ b/template/.github/workflows/test.yml.jinja
@@ -1,7 +1,12 @@
 {%- import 'py-versions.jinja' as python -%}
 name: Run Tests
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - "**.md"
+      - ".vscode/**"
+      - ".cursor/**"
 
 jobs:
   code-checks:


### PR DESCRIPTION
## Summary

  - **Run code checks in a single job** instead of a matrix strategy, reducing CI overhead from 3 parallel jobs to 1 sequential run with a summary table in the GitHub step summary
  - **Limit test matrix to min/max Python versions** via a new `minmax()` Jinja macro, avoiding redundant test runs for intermediate versions
  - **Skip CI for non-code changes** by adding `paths-ignore` for markdown files and IDE/AI config directories (`.vscode/`, `.cursor/`)
  - **Bump `setup-uv` action to v7** with dependency caching enabled

  ## Test plan

  - [x] Verify generated workflow files render correctly with Copier for both `use_uv` and `use_poetry` variants
  - [x] Verify `minmax()` macro returns a single-element list when min == max